### PR TITLE
Fix data.table messing up with vectors

### DIFF
--- a/R/2_example_MNIST.R
+++ b/R/2_example_MNIST.R
@@ -85,8 +85,8 @@ model2 <- xgb.train(params = list(nthread = 4, # More threads if you feel so
 # Try with Multi-Grained Scanning for gcForest ------
 library(plyr)
 create_progress_bar(name = "win") # Get rid of progress bar if you don't like, or set to text
-new_train <- plyr::alply(train, 1, function(x) {matrix(x, nrow = 28, ncol = 28)}, .progress = "win")
-new_test <- plyr::alply(test, 1, function(x) {matrix(x, nrow = 28, ncol = 28)}, .progress = "win")
+new_train <- plyr::alply(train, 1, function(x) {matrix(as.numeric(x), nrow = 28, ncol = 28)}, .progress = "win")
+new_test <- plyr::alply(test, 1, function(x) {matrix(as.numeric(x), nrow = 28, ncol = 28)}, .progress = "win")
 
 # Run Multi-Grained Scanning ------
 new_model <- MGScanning(data = new_train,


### PR DESCRIPTION
This fix should allow to get vectors instead of data.tables which cannot be transformed into matrices, it ensures working in most versions of data.table and R.

In my local version it worked fine, but I got report it does not work in some installations.

Therefore, this fix should ensure a vector and not a data.table as input for the matrix transformation.

Each element of the resulting list:

* Without `as.numeric`: list of 784 elements (??????????)
* With `as.numeric`: matrix of size 28x28
